### PR TITLE
WIP: Extend Expr.reinterpret to arbitrary primitive numeric types

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/crates/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -153,6 +153,18 @@ impl Reinterpret for UInt64Chunked {
         self.clone().into_series()
     }
 }
+
+#[cfg(feature = "reinterpret")]
+impl ReinterpretDType for UInt64Chunked {
+    fn reinterpret_float(&self) -> Series {
+        reinterpret_chunked_array::<_, Float64Type>(self).into_series()
+    }
+
+    fn reinterpret_int(&self) -> Series {
+        self.clone().into_series()
+    }
+}
+
 #[cfg(feature = "reinterpret")]
 impl Reinterpret for Int64Chunked {
     fn reinterpret_signed(&self) -> Series {
@@ -161,6 +173,17 @@ impl Reinterpret for Int64Chunked {
 
     fn reinterpret_unsigned(&self) -> Series {
         self.bit_repr_large().into_series()
+    }
+}
+
+#[cfg(feature = "reinterpret")]
+impl ReinterpretDType for Int64Chunked {
+    fn reinterpret_float(&self) -> Series {
+        reinterpret_chunked_array::<_, Float64Type>(self).into_series()
+    }
+
+    fn reinterpret_int(&self) -> Series {
+        self.clone().into_series()
     }
 }
 
@@ -177,6 +200,17 @@ impl Reinterpret for UInt32Chunked {
 }
 
 #[cfg(feature = "reinterpret")]
+impl ReinterpretDType for UInt32Chunked {
+    fn reinterpret_float(&self) -> Series {
+        reinterpret_chunked_array::<_, Float32Type>(self).into_series()
+    }
+
+    fn reinterpret_int(&self) -> Series {
+        self.clone().into_series()
+    }
+}
+
+#[cfg(feature = "reinterpret")]
 impl Reinterpret for Int32Chunked {
     fn reinterpret_signed(&self) -> Series {
         self.clone().into_series()
@@ -188,6 +222,17 @@ impl Reinterpret for Int32Chunked {
 }
 
 #[cfg(feature = "reinterpret")]
+impl ReinterpretDType for Int32Chunked {
+    fn reinterpret_float(&self) -> Series {
+        reinterpret_chunked_array::<_, Float32Type>(self).into_series()
+    }
+
+    fn reinterpret_int(&self) -> Series {
+        self.clone().into_series()
+    }
+}
+
+#[cfg(feature = "reinterpret")]
 impl Reinterpret for Float32Chunked {
     fn reinterpret_signed(&self) -> Series {
         reinterpret_chunked_array::<_, Int32Type>(self).into_series()
@@ -195,6 +240,17 @@ impl Reinterpret for Float32Chunked {
 
     fn reinterpret_unsigned(&self) -> Series {
         reinterpret_chunked_array::<_, UInt32Type>(self).into_series()
+    }
+}
+
+#[cfg(feature = "reinterpret")]
+impl ReinterpretDType for Float32Chunked {
+    fn reinterpret_float(&self) -> Series {
+        self.clone().into_series()
+    }
+
+    fn reinterpret_int(&self) -> Series {
+        reinterpret_chunked_array::<_, Int32Type>(self).into_series()
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -65,6 +65,16 @@ pub trait Reinterpret {
     }
 }
 
+pub trait ReinterpretDType {
+    fn reinterpret_int(&self) -> Series {
+        unimplemented!()
+    }
+
+    fn reinterpret_float(&self) -> Series {
+        unimplemented!()
+    }
+}
+
 /// Transmute [`ChunkedArray`] to bit representation.
 /// This is useful in hashing context and reduces no.
 /// of compiled code paths.

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5456,7 +5456,7 @@ class Expr:
         k3 = seed_3 if seed_3 is not None else seed
         return self._from_pyexpr(self._pyexpr.hash(k0, k1, k2, k3))
 
-    def reinterpret(self, *, signed: bool = True) -> Self:
+    def reinterpret(self, *, signed: bool = True, int: bool = True) -> Self:
         """
         Reinterpret the underlying bits as a signed/unsigned integer.
 
@@ -5489,7 +5489,7 @@ class Expr:
         │ 2             ┆ 2        │
         └───────────────┴──────────┘
         """
-        return self._from_pyexpr(self._pyexpr.reinterpret(signed))
+        return self._from_pyexpr(self._pyexpr.reinterpret(signed, int))
 
     def inspect(self, fmt: str = "{}") -> Self:
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5468,8 +5468,8 @@ class Expr:
         signed
             If True, reinterpret as `pl.Int64`. Otherwise, reinterpret as `pl.UInt64`.
         int
-            If True, reinterpret as integer with same bit width. Otherwise, reinterpret as float
-            with same bit width.
+            If True, reinterpret as integer with same bit width. Otherwise, reinterpret
+            as float with same bit width.
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5467,6 +5467,9 @@ class Expr:
         ----------
         signed
             If True, reinterpret as `pl.Int64`. Otherwise, reinterpret as `pl.UInt64`.
+        int
+            If True, reinterpret as integer with same bit width. Otherwise, reinterpret as float
+            with same bit width.
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6113,6 +6113,10 @@ class Series:
         ----------
         signed
             If True, reinterpret as `pl.Int64`. Otherwise, reinterpret as `pl.UInt64`.
+        int
+            If True, reinterpret as integer with same bit width. Otherwise, reinterpret as float
+            with same bit width.
+            
         """
 
     def interpolate(self, method: InterpolationMethod = "linear") -> Series:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6114,9 +6114,9 @@ class Series:
         signed
             If True, reinterpret as `pl.Int64`. Otherwise, reinterpret as `pl.UInt64`.
         int
-            If True, reinterpret as integer with same bit width. Otherwise, reinterpret as float
-            with same bit width.
-            
+            If True, reinterpret as integer with same bit width. Otherwise, reinterpret
+            as float with same bit width.
+
         """
 
     def interpolate(self, method: InterpolationMethod = "linear") -> Series:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6102,7 +6102,7 @@ class Series:
         ]
         """
 
-    def reinterpret(self, *, signed: bool = True) -> Series:
+    def reinterpret(self, *, signed: bool = True, int: bool = True) -> Series:
         """
         Reinterpret the underlying bits as a signed/unsigned integer.
 

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -688,8 +688,8 @@ impl PyExpr {
         self.inner.clone().dot(other.inner).into()
     }
 
-    fn reinterpret(&self, signed: bool) -> Self {
-        let function = move |s: Series| reinterpret(&s, signed).map(Some);
+    fn reinterpret(&self, signed: bool, int: bool) -> Self {
+        let function = move |s: Series| reinterpret(&s, signed, int).map(Some);
         let dt = if signed {
             DataType::Int64
         } else {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1251,6 +1251,12 @@ def test_reinterpret() -> None:
     assert s.reinterpret(signed=True).dtype == pl.Int64
     df = pl.DataFrame([s])
     assert df.select([pl.col("a").reinterpret(signed=True)])["a"].dtype == pl.Int64
+    
+def test_reinterpret_float() -> None:
+    s = pl.Series("a", [1, 1, 2], dtype=pl.Int64)
+    assert s.reinterpret(int=False).dtype == pl.Float64
+    df = pl.DataFrame([s])
+    assert df.select([pl.col("a").reinterpret(int=False)])["a"].dtype == pl.Float64
 
 
 def test_mode() -> None:

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1251,7 +1251,8 @@ def test_reinterpret() -> None:
     assert s.reinterpret(signed=True).dtype == pl.Int64
     df = pl.DataFrame([s])
     assert df.select([pl.col("a").reinterpret(signed=True)])["a"].dtype == pl.Int64
-    
+
+
 def test_reinterpret_float() -> None:
     s = pl.Series("a", [1, 1, 2], dtype=pl.Int64)
     assert s.reinterpret(int=False).dtype == pl.Float64


### PR DESCRIPTION
Still a WIP since slightly unclear what the ideal API would be and if the time should be taken to extend Reinterpret and ReinterpretDType to types beyond (U)Int64 and (U)Int32.

Aims to resolve https://github.com/pola-rs/polars/issues/13659